### PR TITLE
Add support for 'off-canvas'

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -87,6 +87,7 @@ if ( ! function_exists( 'flair_setup' ) ) :
 	# add_theme_support( 'foundation-equalizer' );
 	# add_theme_support( 'foundation-accordion' );
 	# add_theme_support( 'foundation-tabs' );
+	# add_theme_support( 'off-canvas' );
 	# add_theme_support( 'remove-comments' );
 
 }

--- a/inc/foundation-theme-support.php
+++ b/inc/foundation-theme-support.php
@@ -62,7 +62,7 @@ function flair_check_theme_support() {
 	if ( current_theme_supports( 'foundation-tabs' ) ) {
 		add_action( 'wp_enqueue_scripts',  'flair_enqueue_tabs', 11 );
 	}
-	
+
 	if ( current_theme_supports( 'foundation-off-canvas' ) ) {
 		add_action( 'wp_enqueue_scripts',  'flair_off_canvas', 11 );
 	}

--- a/inc/foundation-theme-support.php
+++ b/inc/foundation-theme-support.php
@@ -62,6 +62,10 @@ function flair_check_theme_support() {
 	if ( current_theme_supports( 'foundation-tabs' ) ) {
 		add_action( 'wp_enqueue_scripts',  'flair_enqueue_tabs', 11 );
 	}
+	
+	if ( current_theme_supports( 'foundation-off-canvas' ) ) {
+		add_action( 'wp_enqueue_scripts',  'flair_off_canvas', 11 );
+	}
 
 }
 
@@ -205,6 +209,16 @@ function flair_enqueue_accordion() {
 
 function flair_enqueue_tabs() {
 	wp_enqueue_script( 'tabs', get_template_directory_uri() . '/assets/js/foundation/foundation.tab.js', array( 'jquery', 'foundation' ), FOUNDATION_VERSION, true );
+}
+
+/**
+ * Enqueue Foundation Off Canvas Menus
+ *
+ * http://foundation.zurb.com/docs/components/offcanvas.html
+ */
+
+function flair_off_canvas() {
+	wp_enqueue_script( 'offcanvas', get_template_directory_uri() . '/assets/js/foundation/foundation.offcanvas.js', array( 'jquery', 'foundation' ), FOUNDATION_VERSION, true );
 }
 
 /**


### PR DESCRIPTION
Off-canvas js isn't enqueued or optional as a 'add_theme_support' option

https://github.com/sennza/lorna-jane/commit/4e3974e644e5fbef16c052e50f27a26c6d1d1732