### PR TITLE
Add a 'grunt build' that creates a zip of the WordPress theme for distribution

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,19 @@ module.exports = function(grunt) {
 				'scss/_settings.scss': 'foundation/scss/foundation/_settings.scss'
 			}
 		}
+	},
+	imagemin: {
+		build: {
+			files: [{
+				expand: true,
+				cwd: './assets/images/',
+				src: ['**/*.{png,jpg,gif}'],
+				dest: './assets/images/'
+			}],
+				options: {
+				optimizationLevel: 7
+			}
+		}
 	}
 
 });
@@ -82,8 +95,9 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-contrib-compress');
+	grunt.loadNpmTasks('grunt-contrib-imagemin');
 
 	grunt.registerTask('setup', ['bowercopy','sass']);
 	grunt.registerTask('default', ['sass','watch']);
-	grunt.registerTask('build', ['sass', 'copy', 'compress']);
+	grunt.registerTask('build', ['sass', 'copy', 'compress', 'imagemin']);
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "grunt-contrib-sass": "~0.8.1",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-compress": "~0.9.1",
-    "grunt-bowercopy": "1.0.0"
+    "grunt-bowercopy": "1.0.0",
+    "grunt-contrib-imagemin": "~0.5.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should include:

- [x] No Sass partials
- [x] None of the following files `.bowerrc`, `.gitignore`, `Gruntfile.js`, `README.md`, `bower.json`, `package.json`
- [x] Minify CSS files
- [x] Optimise all images

https://github.com/sennza/Flair/issues/16 will need to be dealt with before we tackle this.