### PR TITLE
Reposition prematurely closed div tag

### DIFF
--- a/inc/foundation-filters.php
+++ b/inc/foundation-filters.php
@@ -290,6 +290,7 @@ function flair_gform_get_name_field( $field, $value, $lead_id, $form_id ) {
 	<div id="input_<?php esc_attr_e( $input_id ); ?>_container" class="<?php echo apply_filters( 'ebisprint_gforms_name_class', 'large-6 columns', $field, $form_id, $input_id ); ?>">
 	<input id="input_<?php esc_attr_e( $input_id ); ?>" type="text" tabindex="<?php esc_attr_e( $field['id'] ); ?>" name="input_<?php esc_attr_e( $input_id ); ?>"
 	       placeholder="<?php esc_attr_e( $field['label'] ); ?>" class="<?php echo apply_filters( 'ebisprint_gforms_name_field_class', 'placeholder ', $field, $form_id, $input_id ); ?>" />
+	</div>
 
 <?php else : ?>
 	<?php foreach ( $field['inputs'] as $key => $input ) :
@@ -321,7 +322,6 @@ function flair_gform_get_name_field( $field, $value, $lead_id, $form_id ) {
 		</div>
 	<?php endforeach; ?>
 <?php endif; ?>
-	</div>
 	<?php
 	$output = ob_get_contents();
 	ob_end_clean();


### PR DESCRIPTION
@BronsonQuick The trailing closing div would prematurely break the content divs. Refactored.